### PR TITLE
Ignore rtd_tests folder

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -11,6 +11,7 @@ ignore-paths:
   - docs/
 
 ignore-patterns:
+  - rtd_tests/
   - /migrations/
   - local_settings.py
 


### PR DESCRIPTION
The current patterns don't ignore all the folder

https://github.com/PyCQA/prospector/blob/master/prospector/profiles/profiles/no_test_warnings.yaml