### PR TITLE
Disable useless-object-inheritance since we run linting on Python3

### DIFF
--- a/prospector.yml
+++ b/prospector.yml
@@ -28,6 +28,9 @@ pylint:
   disable:
     - logging-format-interpolation
     - inconsistent-return-statements
+    # We are running lint with Python 3.x but we still support Python 2.x
+    # (corporate site is under Python 2.x)
+    - useless-object-inheritance
 
 mccabe:
   run: false


### PR DESCRIPTION
We do want to support Python 2.x since our Corporate site runs 2.x still.

We skip this check for now and we will re-enable it once all of our code base be under Python 3.x

Related: https://github.com/rtfd/readthedocs.org/pull/4318