### PR TITLE
Fix cyclical changes and flake8 failure

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -2,10 +2,11 @@ exclude: '^$'
 fail_fast: false
 repos:
 
-- repo: https://github.com/asottile/add-trailing-comma
-  sha: v0.6.4
-  hooks:
-    - id: add-trailing-comma
+# Conflicts with YAPF trailing comma
+#- repo: https://github.com/asottile/add-trailing-comma
+#  sha: v0.6.4
+#  hooks:
+#    - id: add-trailing-comma
 
 - repo: git@github.com:humitos/mirrors-autoflake.git
   rev: v1.1
@@ -21,11 +22,12 @@ repos:
       additional_dependencies: ['futures']
       args: ['--style=.style.yapf', '--parallel', '--in-place']
 
-- repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
-  rev: b57843b0b874df1d16eb0bef00b868792cb245c2
-  hooks:
-    - id: python-import-sorter
-      args: ['--silent-overwrite']
+# Also conflicts with YAPF trailing comma
+#- repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
+#  rev: b57843b0b874df1d16eb0bef00b868792cb245c2
+#  hooks:
+#    - id: python-import-sorter
+#      args: ['--silent-overwrite', '--diff']
 
 - repo: git@github.com:humitos/mirrors-docformatter.git
   rev: v1.0
@@ -34,7 +36,7 @@ repos:
       args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
 
 - repo: git@github.com:pre-commit/pre-commit-hooks
-  rev: v1.2.3
+  rev: v1.4.0
   hooks:
     - id: autopep8-wrapper
     - id: check-added-large-files
@@ -45,24 +47,25 @@ repos:
     - id: check-merge-conflict
     - id: check-symlinks
     - id: trailing-whitespace
-    - id: flake8
-      additional_dependencies: [
-      'flake8-blind-except',
-      'flake8-coding',
-      'flake8-commas',
-      'flake8-comprehensions',
-      'flake8-debugger',
-      'flake8-deprecated',
-      'flake8-docstrings',
-      'flake8-meiqia',
-      'flake8-mutable',
-      'flake8-pep3101',
-      'flake8-print',
-      'flake8-quotes',
-      'flake8-string-format',
-      'flake8-tidy-imports',
-      'flake8-todo']
-      exclude: 'test_oauth.py'
+# Flake8 fails consistently because of bad pydocstyle dependency
+#    - id: flake8
+#      additional_dependencies: [
+#      'flake8-blind-except',
+#      'flake8-coding',
+#      'flake8-commas',
+#      'flake8-comprehensions',
+#      'flake8-debugger',
+#      'flake8-deprecated',
+#      'flake8-docstrings',
+#      'flake8-meiqia',
+#      'flake8-mutable',
+#      'flake8-pep3101',
+#      'flake8-print',
+#      'flake8-quotes',
+#      'flake8-string-format',
+#      'flake8-tidy-imports',
+#      'flake8-todo']
+#      exclude: 'test_oauth.py'
 
 - repo: git://github.com/guykisel/prospector-mirror
   rev: b27f281eb9398fc8504415d7fbdabf119ea8c5e1


### PR DESCRIPTION
Flake8 just straight up fails and I don't know how to make it require a
later pydocstyle. The other two plugins just continually make cyclical
changes, mostly to __future__ imports, so i've removed them. I'm not
super familiar with the fallout though:

- What is adding __future__ in a bad format in the first place?
- Can we make python sort plugin use a not bad format?
- Can we set up order of plugins so at least changes are rewritten in
  the wrong order, creating cyclical changes?
- What is going to do python import sorting if this plugin is removed?