### PR TITLE
Improves for pre-commit configs

### DIFF
--- a/isort.cfg
+++ b/isort.cfg
@@ -1,7 +1,23 @@
 [settings]
 line_length=80
-indent='    '
-multi_line_output=4
+indent=4
+
+# TODO: I think we want ``4 (Hanging Grid)`` but given the problems we
+# are having with yapf and add-trailing-comma; we are force to use 3.
+multi_line_output=3
+
+# TODO: yapf uses 1 line. Changing this setting will interfers with
+# yapf that doesn't have a way to set this value. I prefer 2.
+lines_after_imports=1
+
+combine_as_imports=False
+force_adds=False
+combine_star=False
+include_trailing_comma=True
+use_parentheses=True
+from_first=False
+force_alphabetical_sort=False
+
 default_section=THIRDPARTY
 known_first_party=readthedocs,readthedocsinc
 known_third_party=mock,builtins

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
 
 - repo: git@github.com:pre-commit/mirrors-yapf.git
-  rev: v0.22.0
+  rev: v0.23.0
   hooks:
     - id: yapf
       exclude: 'migrations|settings|scripts'

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -51,17 +51,19 @@ repos:
       'flake8-coding',
       'flake8-commas',
       'flake8-comprehensions',
-      'flake8-debugger',
       'flake8-deprecated',
       'flake8-docstrings',
       'flake8-meiqia',
       'flake8-mutable',
       'flake8-pep3101',
-      'flake8-print',
       'flake8-quotes',
       'flake8-string-format',
       'flake8-tidy-imports',
-      'flake8-todo']
+      # These are good but are broken with current pydocstyle version
+      # 'flake8-print',
+      # 'flake8-debugger',
+      # 'flake8-todo',
+      ]
       exclude: 'test_oauth.py'
 
 - repo: git://github.com/guykisel/prospector-mirror

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -3,7 +3,7 @@ fail_fast: false
 repos:
 
 - repo: https://github.com/asottile/add-trailing-comma
-  sha: v0.6.4
+  sha: v0.7.0
   hooks:
     - id: add-trailing-comma
 

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -47,6 +47,8 @@ repos:
     - id: check-merge-conflict
     - id: check-symlinks
     - id: trailing-whitespace
+    - id: mixed-line-ending
+      args: ['--fix=lf']
     - id: flake8
       additional_dependencies: [
       'flake8-blind-except',

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       args: ['--style=.style.yapf', '--parallel', '--in-place']
 
 - repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
-  rev: b57843b0b874df1d16eb0bef00b868792cb245c2
+  rev: b57843b0b874df1d16eb0bef00b868792cb245c2  # higher than 1.0.4 (latest release)
   hooks:
     - id: python-import-sorter
       args: ['--silent-overwrite']

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       additional_dependencies: ['futures']
       args: ['--style=.style.yapf', '--parallel', '--in-place']
 
+# When calling `pre-commit autoupdate`, this repo needs to be commented because it fails
 - repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
   rev: b57843b0b874df1d16eb0bef00b868792cb245c2  # higher than 1.0.4 (latest release)
   hooks:

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -37,7 +37,8 @@ repos:
 - repo: git@github.com:pre-commit/pre-commit-hooks
   rev: v1.4.0
   hooks:
-    - id: autopep8-wrapper
+    # Disabled because yapf is better for our purpose
+    # - id: autopep8-wrapper
     - id: check-added-large-files
     - id: debug-statements
     - id: double-quote-string-fixer

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
 
 - repo: git@github.com:pre-commit/pre-commit-hooks
-  rev: v1.2.3
+  rev: v1.4.0
   hooks:
     - id: autopep8-wrapper
     - id: check-added-large-files

--- a/style.yapf
+++ b/style.yapf
@@ -222,7 +222,7 @@ SPLIT_PENALTY_FOR_ADDED_LINE_SPLIT=30
 #
 #   from a_very_long_or_indented_module_name_yada_yad import (
 #       long_argument_1, long_argument_2, long_argument_3)
-SPLIT_PENALTY_IMPORT_NAMES=0
+SPLIT_PENALTY_IMPORT_NAMES=1000
 
 # The penalty of splitting the line around the 'and' and 'or'
 # operators.

--- a/style.yapf
+++ b/style.yapf
@@ -1,6 +1,6 @@
 # https://github.com/google/yapf
 # current version used in this repo
-# yapf==0.21.0
+# yapf==0.23.0
 
 
 [style]
@@ -93,6 +93,10 @@ CONTINUATION_INDENT_WIDTH=4
 #   )        # <--- this bracket is dedented and on a separate line
 DEDENT_CLOSING_BRACKETS=True
 
+# Disable the heuristic which places each list element on a separate
+# line if the list is comma-terminated.
+DISABLE_ENDING_COMMA_HEURISTIC=False
+
 # Place each dictionary entry onto its own line.
 EACH_DICT_ENTRY_ON_SEPARATE_LINE=False
 
@@ -150,7 +154,7 @@ SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=True
 # If a comma separated list (dict, list, tuple, or function def) is on
 # a line that is too long, split such that all elements are on a
 # single line.
-SPLIT_ALL_COMMA_SEPARATED_VALUES=True
+SPLIT_ALL_COMMA_SEPARATED_VALUES=False
 
 # Set to True to prefer splitting before '&', '|' or '^' rather than
 # after.
@@ -202,7 +206,7 @@ SPLIT_PENALTY_BITWISE_OPERATOR=300
 SPLIT_PENALTY_COMPREHENSION=80
 
 # The penalty for characters over the column limit.
-SPLIT_PENALTY_EXCESS_CHARACTER=2600
+SPLIT_PENALTY_EXCESS_CHARACTER=50
 
 # The penalty incurred by adding a line split to the unwrapped
 # line. The more line splits added the higher the penalty.


### PR DESCRIPTION
Updated all the plugins and disabled the ones that were failing (`flake8`).

At the moment, we can't get to a status where `pre-commit` works exactly as we want. In other words, the flow we want is:

1. run `pre-commit`
1. some plugins fail but make their changes
1. some other plugins fail and changes are manually done
1. those changes are staged
1. run `pre-commit`
1. all green

Currently, this is not possible for different reasons:

1. we want to sort imports by using `isort` since it's the best one. Although, `yapf` has no option to disable touching the imports. Because of this reason, we need to run first `yapf` (will touch the import and so fail) and _after that_ call `isort` (will touch the imports and fail).
1. for multi lines that do not end on a comma, we want to add the trailing comma. To do this, we use `add-trailing-comma` plugin which is great. Although, we don't want this plugin to touch our imports but there is no option to disable it. Then, after this plugin is ran, `yapf` will also try to do something with the imports, and because of this, it will fail

```diff
# add-trailing-comma
from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import, division, print_function, unicode_literals,
+)
```

```diff
# yapf
 from __future__ import (
-    absolute_import, division, print_function, unicode_literals)
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
```

I configured `isort` to behaves as `yapf` for now to try to avoid this kind of issues. Although, I think the preferred way to sort the import is 

```python
from __future__ import (
    absolute_import, division, print_function, unicode_literals)
```

Anyway, once they implement these settings we need, changing this is really easy to make all of our code to follow the new standard.

> NOTE: the order of the calls of these plugins (`yapf`, `isort` and `add-trailing-comma`) is important. Otherwise, we will end up with a style that we don't want.

Related #16