### PR TITLE
Fix writing setup.cfg in binary mode.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,7 @@ Label = namedtuple('Label', ['name', 'color', 'desc', 'transpose'])
 
 
 @task
-def prepare(ctx, version, since=None):
+def prepare(ctx, version, since=None, path=None):
     """
     Prepare the next release version by updating files.
 
@@ -46,7 +46,9 @@ def prepare(ctx, version, since=None):
     for the new version.
     """
     print('Updating release version in setup.cfg')
-    setupcfg_path = os.path.join(REPO_PATH, 'setup.cfg')
+    if not path:
+        path = REPO_PATH
+    setupcfg_path = os.path.join(path, 'setup.cfg')
     config = RawConfigParser()
     config.read(setupcfg_path)
 
@@ -72,13 +74,13 @@ def prepare(ctx, version, since=None):
         # correct. This can change depending on git reset, etc.
         git_log = ctx.run('git log -1 --format="%ad" -- CHANGELOG.rst')
         since = parse(git_log.stdout.strip()).strftime('%Y-%m-%d')
-    changelog_path = os.path.join(REPO_PATH, 'CHANGELOG.rst')
+    changelog_path = os.path.join(path, 'CHANGELOG.rst')
     template_path = os.path.join(
-        REPO_PATH,
+        path,
         'common',
         'changelog.hbs',
     )
-    bin_path = os.path.join(REPO_PATH, 'node_modules', '.bin')
+    bin_path = os.path.join(path, 'node_modules', '.bin')
     cmd = (
         '{bin_path}/gh-changelog '
         '-o {owner} -r {repository} '

--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,7 @@ Label = namedtuple('Label', ['name', 'color', 'desc', 'transpose'])
 
 
 @task
-def prepare(ctx, version, since=None, path=REPO_PATH):
+def prepare(ctx, version, path=REPO_PATH, since=None):
     """
     Prepare the next release version by updating files.
 

--- a/tasks.py
+++ b/tasks.py
@@ -32,7 +32,7 @@ Label = namedtuple('Label', ['name', 'color', 'desc', 'transpose'])
 
 
 @task
-def prepare(ctx, version, since=None, path=None):
+def prepare(ctx, version, since=None, path=REPO_PATH):
     """
     Prepare the next release version by updating files.
 
@@ -46,8 +46,6 @@ def prepare(ctx, version, since=None, path=None):
     for the new version.
     """
     print('Updating release version in setup.cfg')
-    if not path:
-        path = REPO_PATH
     setupcfg_path = os.path.join(path, 'setup.cfg')
     config = RawConfigParser()
     config.read(setupcfg_path)

--- a/tasks.py
+++ b/tasks.py
@@ -61,7 +61,7 @@ def prepare(ctx, version, since=None):
 
     # Set the release number
     config.set('metadata', 'version', version)
-    with open(setupcfg_path, 'wb') as configfile:
+    with open(setupcfg_path, 'w') as configfile:
         config.write(configfile)
 
     # Install and run


### PR DESCRIPTION
This was causing this error:

```
  File "/Users/eric/projects/readthedocs.org/tasks.py", line 65, in prepare
    config.write(configfile)
  File "/usr/local/Cellar/python/3.6.5_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 919, in write
    self._sections[section].items(), d)
  File "/usr/local/Cellar/python/3.6.5_1/Frameworks/Python.framework/Versions/3.6/lib/python3.6/configparser.py", line 923, in _write_section
    fp.write("[{}]\n".format(section_name))
TypeError: a bytes-like object is required, not 'str'
```