### PR TITLE
Initial configuration for pre-commit with black

### DIFF
--- a/flake8
+++ b/flake8
@@ -1,3 +1,36 @@
 [flake8]
-ignore = C818,C819,E125,D100,D101,D102,D103,D105,D106,D107,D200,D202,D211,D403,P101,FI15,FI16,FI12,FI11,FI17,FI50,FI53,FI54,MQ101,T000
-max-line-length = 80
+ignore =
+  C812,  # missing trailing comma
+  C818,
+  C819,
+  D100,
+  D101,
+  D102,
+  D103,
+  D105,
+  D106,
+  D107,
+  D200,
+  D202,
+  D211,
+  D403,
+
+  E125,  # continuation line with same indent as next logical line
+
+  FI15,
+  FI16,
+  FI12,
+  FI11,
+  FI17,
+  FI50,
+  FI53,
+  FI54,
+
+  MQ101,
+
+  P101,
+
+  Q000,
+  T000,
+  W503  # line break before binary operator
+max-line-length = 88

--- a/isort.cfg
+++ b/isort.cfg
@@ -1,16 +1,16 @@
 [settings]
-line_length=80
-indent=4
-
-# TODO: I think we want ``4 (Hanging Grid)`` but given the problems we
-# are having with yapf and add-trailing-comma; we are force to use 3.
+# Compatible with black
+# https://black.readthedocs.io/en/stable/the_black_code_style.html
 multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88
 
+indent=4
 lines_after_imports=2
-combine_as_imports=False
 force_adds=False
 combine_star=False
-include_trailing_comma=True
 use_parentheses=True
 from_first=False
 force_alphabetical_sort=False

--- a/pep8
+++ b/pep8
@@ -1,3 +1,3 @@
 [pep8]
 ignore = E701,E70,E702
-max-line-length = 80
+max-line-length = 88

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -2,23 +2,11 @@ exclude: 'migrations|settings|scripts|tests'
 fail_fast: false
 repos:
 
-- repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.7.0
+- repo: https://github.com/ambv/black
+  rev: 18.9b0
   hooks:
-    - id: add-trailing-comma
-
-- repo: git@github.com:humitos/mirrors-autoflake.git
-  rev: v1.1
-  hooks:
-    - id: autoflake
-      args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
-
-- repo: git@github.com:pre-commit/mirrors-yapf.git
-  rev: v0.25.0
-  hooks:
-    - id: yapf
-      additional_dependencies: ['futures']
-      args: ['--style=.style.yapf', '--parallel', '--in-place']
+    - id: black
+      language_version: python3.6
 
 # When calling `pre-commit autoupdate`, this repo needs to be commented because it fails
 - repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
@@ -31,26 +19,23 @@ repos:
   rev: v1.0
   hooks:
     - id: docformatter
-      args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
+      args: ['--in-place', '--wrap-summaries=88', '--wrap-descriptions=88', '--pre-summary-newline']
 
 - repo: git@github.com:pre-commit/pre-commit-hooks
   rev: v1.4.0
   hooks:
-    # Disabled because yapf is better for our purpose
-    # - id: autopep8-wrapper
     - id: check-added-large-files
     - id: debug-statements
-    - id: double-quote-string-fixer
     - id: end-of-file-fixer
     - id: fix-encoding-pragma
     - id: check-merge-conflict
     - id: check-symlinks
-    - id: trailing-whitespace
     - id: mixed-line-ending
       args: ['--fix=lf']
     - id: flake8
       additional_dependencies: [
       'flake8-blind-except',
+      'flake8-bugbear',
       'flake8-coding',
       'flake8-commas',
       'flake8-comprehensions',
@@ -67,7 +52,6 @@ repos:
       # 'flake8-debugger',
       # 'flake8-todo',
       ]
-      exclude: 'test_oauth.py'
 
 - repo: git://github.com/guykisel/prospector-mirror
   rev: b27f281eb9398fc8504415d7fbdabf119ea8c5e1


### PR DESCRIPTION
We change the usage of yapf plus a very customized group of external plugins to only rely on black (for auto-linting) + flake8 (warning checks) + isort (auto-sort import) + docformatter (auto-lint docstring)

This configuration is way more easy to mantain since there is not too many options to configure the auto linting.

The only configuration files are the ones for the warning checks that can be adapted/tunned over time if needed.

Related #22