### PR TITLE
Use default isort lines after import statements

### DIFF
--- a/isort.cfg
+++ b/isort.cfg
@@ -6,11 +6,7 @@ indent=4
 # are having with yapf and add-trailing-comma; we are force to use 3.
 multi_line_output=3
 
-# I dislike 1 line after imports, and PEP8 says 2, but yapf insists on 1 line.
-# Setting isort to 1 line here avoids a circular lint fix situation. Feature
-# request on yapf for this is:
-# https://github.com/google/yapf/issues/347
-lines_after_imports=1
+lines_after_imports=-1
 combine_as_imports=False
 force_adds=False
 combine_star=False

--- a/isort.cfg
+++ b/isort.cfg
@@ -6,7 +6,11 @@ indent=4
 # are having with yapf and add-trailing-comma; we are force to use 3.
 multi_line_output=3
 
-lines_after_imports=2
+# I dislike 1 line after imports, and PEP8 says 2, but yapf insists on 1 line.
+# Setting isort to 1 line here avoids a circular lint fix situation. Feature
+# request on yapf for this is:
+# https://github.com/google/yapf/issues/347
+lines_after_imports=1
 combine_as_imports=False
 force_adds=False
 combine_star=False


### PR DESCRIPTION
This is not ideal, but solves the issue of a cyclical lint fix when yapf
and isort disagree on the number of lines after imports.