### PR TITLE
Mark recommonmark to not be upgraded

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -335,6 +335,7 @@ def upgrade_all_packages(ctx, skip=False, patch=False, packages=None):
         packages = (
             'redis',
             'commonmark',
+            'recommonmark',
             'django',
             'docker',
             'celery',


### PR DESCRIPTION
Newer `recommonmark` is not compatible with our code.

See https://github.com/rtfd/readthedocs.org/pull/5134