### PR TITLE
Remove encoding

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     - id: end-of-file-fixer
       exclude: 'static'
     - id: fix-encoding-pragma
+      args: ['--remove']
     - id: check-merge-conflict
     - id: check-symlinks
     - id: trailing-whitespace
@@ -54,7 +55,6 @@ repos:
     - id: flake8
       additional_dependencies: [
       'flake8-blind-except',
-      'flake8-coding',
       'flake8-commas',
       'flake8-comprehensions',
       'flake8-deprecated',

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -7,34 +7,6 @@ repos:
 #   hooks:
 #     - id: add-trailing-comma
 
-- repo: git@github.com:humitos/mirrors-autoflake.git
-  rev: v1.1
-  hooks:
-    - id: autoflake
-      args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
-
-- repo: git@github.com:pre-commit/mirrors-yapf.git
-  rev: v0.25.0
-  hooks:
-    - id: yapf
-      exclude: 'migrations|tests'
-      args: ['--style=.style.yapf', '--parallel', '--in-place']
-
-# When calling `pre-commit autoupdate`, this repo needs to be commented because it fails
-- repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
-  rev: b57843b0b874df1d16eb0bef00b868792cb245c2  # higher than 1.0.4 (latest release)
-  hooks:
-    - id: python-import-sorter
-      args: ['--silent-overwrite']
-      exclude: 'wsgi.py'
-
-- repo: git@github.com:myint/docformatter.git
-  # Latest release v1.0 does not contains the .pre-commit-hooks.yaml file
-  rev: 7cb0c50b674680e28cae8c4c1add6b43ed2ccb91
-  hooks:
-    - id: docformatter
-      args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
-
 - repo: git@github.com:pre-commit/pre-commit-hooks
   rev: v2.1.0
   hooks:
@@ -70,6 +42,34 @@ repos:
       # 'flake8-debugger',
       # 'flake8-todo',
       ]
+
+- repo: git@github.com:humitos/mirrors-autoflake.git
+  rev: v1.1
+  hooks:
+    - id: autoflake
+      args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+
+- repo: git@github.com:pre-commit/mirrors-yapf.git
+  rev: v0.25.0
+  hooks:
+    - id: yapf
+      exclude: 'migrations|tests'
+      args: ['--style=.style.yapf', '--parallel', '--in-place']
+
+# When calling `pre-commit autoupdate`, this repo needs to be commented because it fails
+- repo: git@github.com:FalconSocial/pre-commit-python-sorter.git
+  rev: b57843b0b874df1d16eb0bef00b868792cb245c2  # higher than 1.0.4 (latest release)
+  hooks:
+    - id: python-import-sorter
+      args: ['--silent-overwrite']
+      exclude: 'wsgi.py'
+
+- repo: git@github.com:myint/docformatter.git
+  # Latest release v1.0 does not contains the .pre-commit-hooks.yaml file
+  rev: 7cb0c50b674680e28cae8c4c1add6b43ed2ccb91
+  hooks:
+    - id: docformatter
+      args: ['--in-place', '--wrap-summaries=80', '--wrap-descriptions=80', '--pre-summary-newline']
 
 - repo: git://github.com/guykisel/prospector-mirror
   rev: 7ff847e779347033ebbd9e3b88279e7f3a998b45


### PR DESCRIPTION
Fixes first part of #30 

I added `--remove` to the plugin and also removed the flake8 check for the encoding.

Besides, as the `--remove` only removes the encoding line, there was an empty line at the beginning of the line. So, to avoid this and get automatically fixed, I'm running first all these small linters (including the one that removes the encoding) and after them the bigger ones `isort`, `yapf`, etc.